### PR TITLE
Fix spawner merging bug

### DIFF
--- a/src/main/java/me/xhyrom/spawnergenz/listeners/ClickListener.java
+++ b/src/main/java/me/xhyrom/spawnergenz/listeners/ClickListener.java
@@ -106,7 +106,11 @@ public class ClickListener implements Listener {
                     int amount = count - actuallyMerged;
 
                     if (amount == 0) {
-                        player.getInventory().setItemInMainHand(null);
+                        if (itemInHand.getAmount() == 1) {
+                            player.getInventory().setItemInMainHand(null);
+                        } else {
+                            itemInHand.setAmount(itemInHand.getAmount() - 1);
+                        }
                     } else {
                         itemInHandPDC.set(countKey, PersistentDataType.INTEGER, amount);
 


### PR DESCRIPTION
This PR fixes a bug that would occur if the player is holding more than one "stacked" spawner in their hand and they crouch and merge it their hand would be set to air and they would loose all other stacks in that hand.