### PR TITLE
Merging bug fixes

### DIFF
--- a/src/main/java/me/xhyrom/spawnergenz/listeners/ClickListener.java
+++ b/src/main/java/me/xhyrom/spawnergenz/listeners/ClickListener.java
@@ -154,6 +154,11 @@ public class ClickListener implements Listener {
                     if (itemInHand.getAmount() == 1) {
                         player.getInventory().setItemInMainHand(null);
                     } else {
+                        // If the pdc count is 1 then we can just remove the item
+                        if (count == 1) {
+                            itemInHand.setAmount(itemInHand.getAmount() - 1);
+                            return;
+                        }
                         ItemStack clone = itemInHand.clone();
                         ItemMeta cloneMeta = clone.getItemMeta();
                         PersistentDataContainer clonePDC = cloneMeta.getPersistentDataContainer();
@@ -169,6 +174,12 @@ public class ClickListener implements Listener {
                                         spawner.getCreatureSpawner().getSpawnedType().name()
                                 ))
                         ));
+
+                        clone.setItemMeta(cloneMeta);
+
+                        itemInHand.setAmount(itemInHand.getAmount() - 1);
+
+                        player.getInventory().addItem(clone);
                     }
                 }
             } else {

--- a/src/main/java/me/xhyrom/spawnergenz/listeners/ClickListener.java
+++ b/src/main/java/me/xhyrom/spawnergenz/listeners/ClickListener.java
@@ -106,26 +106,70 @@ public class ClickListener implements Listener {
                     int amount = count - actuallyMerged;
 
                     if (amount == 0) {
-                        player.getInventory().setItemInMainHand(null);
+                        if (itemInHand.getAmount() == 1) {
+                            player.getInventory().setItemInMainHand(null);
+                        } else {
+                            itemInHand.setAmount(itemInHand.getAmount() - 1);
+                        }
                     } else {
-                        itemInHandPDC.set(countKey, PersistentDataType.INTEGER, amount);
+                        if (itemInHand.getAmount() == 1) {
+                            itemInHandPDC.set(countKey, PersistentDataType.INTEGER, amount);
 
-                        itemInHandMeta.displayName(MiniMessage.miniMessage().deserialize(
-                                SpawnerGenz.getInstance().getConfig().getString("item-spawner-name"),
-                                Placeholder.parsed("amount", String.valueOf(amount)),
-                                Placeholder.parsed("spawner_type", Utils.convertUpperSnakeCaseToPascalCase(
-                                        spawner.getCreatureSpawner().getSpawnedType().name()
-                                ))
-                        ));
+                            itemInHandMeta.displayName(MiniMessage.miniMessage().deserialize(
+                                    SpawnerGenz.getInstance().getConfig().getString("item-spawner-name"),
+                                    Placeholder.parsed("amount", String.valueOf(amount)),
+                                    Placeholder.parsed("spawner_type", Utils.convertUpperSnakeCaseToPascalCase(
+                                            spawner.getCreatureSpawner().getSpawnedType().name()
+                                    ))
+                            ));
 
-                        itemInHand.setItemMeta(itemInHandMeta);
+                            itemInHand.setItemMeta(itemInHandMeta);
+                        } else {
+                            ItemStack clone = itemInHand.clone();
+                            ItemMeta cloneMeta = clone.getItemMeta();
+                            PersistentDataContainer clonePDC = cloneMeta.getPersistentDataContainer();
+
+                            clone.setAmount(1);
+
+                            clonePDC.set(countKey, PersistentDataType.INTEGER, amount);
+
+                            cloneMeta.displayName(MiniMessage.miniMessage().deserialize(
+                                    SpawnerGenz.getInstance().getConfig().getString("item-spawner-name"),
+                                    Placeholder.parsed("amount", String.valueOf(amount)),
+                                    Placeholder.parsed("spawner_type", Utils.convertUpperSnakeCaseToPascalCase(
+                                            spawner.getCreatureSpawner().getSpawnedType().name()
+                                    ))
+                            ));
+
+                            clone.setItemMeta(cloneMeta);
+
+                            itemInHand.setAmount(itemInHand.getAmount() - 1);
+
+                            player.getInventory().addItem(clone);
+                        }
                     }
                 } else {
                     spawner.setCount(spawner.getCount() + 1);
 
                     if (itemInHand.getAmount() == 1) {
                         player.getInventory().setItemInMainHand(null);
-                    } else itemInHand.setAmount(itemInHand.getAmount() - 1);
+                    } else {
+                        ItemStack clone = itemInHand.clone();
+                        ItemMeta cloneMeta = clone.getItemMeta();
+                        PersistentDataContainer clonePDC = cloneMeta.getPersistentDataContainer();
+
+                        clone.setAmount(1);
+
+                        clonePDC.set(countKey, PersistentDataType.INTEGER, count - 1);
+
+                        cloneMeta.displayName(MiniMessage.miniMessage().deserialize(
+                                SpawnerGenz.getInstance().getConfig().getString("item-spawner-name"),
+                                Placeholder.parsed("amount", String.valueOf(count - 1)),
+                                Placeholder.parsed("spawner_type", Utils.convertUpperSnakeCaseToPascalCase(
+                                        spawner.getCreatureSpawner().getSpawnedType().name()
+                                ))
+                        ));
+                    }
                 }
             } else {
                 player.sendMessage(MiniMessage.miniMessage().deserialize(


### PR DESCRIPTION
Fixes 2 bugs when merging spawners with multiple spawners in the same itemstack.

For example if a player had a spawner placed at 250 (Assume the max is 256) and they had 3x (In the same itemstack) 180 spawners and they sneak merged the amount would be set on all 3 instead of just one. A similar bug happens when merging a single spawner.

This PR should fix that